### PR TITLE
Use single script for both dry-run and regular format

### DIFF
--- a/format-objc-file.sh
+++ b/format-objc-file.sh
@@ -17,20 +17,5 @@ fi
 line="$(head -1 "$1" | xargs)" 
 [ "$line" == "#pragma Formatter Exempt" -o "$line" == "// MARK: Formatter Exempt" ] && exit 0
 
-# Fix an edge case with array / dictionary literals that confuses clang-format
-python "$DIR"/custom/LiteralSymbolSpacer.py "$1"
-# The formatter gets confused by C++ inline constructors that are broken onto multiple lines
-python "$DIR"/custom/InlineConstructorOnSingleLine.py "$1"
-# Add a semicolon at the end of simple macros
-python "$DIR"/custom/MacroSemicolonAppender.py "$1"
-
-# Run clang-format
-"$DIR"/bin/clang-format-3.8-custom -i -style=file "$1" ;
-# Fix an issue with clang-format getting confused by categories with generic expressions.
-python "$DIR"/custom/GenericCategoryLinebreakIndentation.py "$1"
-# Fix an issue with clang-format breaking up a lone parameter onto a newline after a block literal argument.
-python "$DIR"/custom/ParameterAfterBlockNewline.py "$1"
-# Fix an issue with clang-format inserting spaces in a preprocessor macro.
-python "$DIR"/custom/HasIncludeSpaceRemover.py "$1"
-# Add a newline at the end of the file
-python "$DIR"/custom/NewLineAtEndOfFileInserter.py "$1"
+DRYRUN=`"$DIR"/format-objc-file-dry-run.sh "$1"`
+echo "$DRYRUN" > $1


### PR DESCRIPTION
Use single script for both dry-run and regular format

More specifically, use the 

format-objc-file-dry-run.sh

as the basis for

format-objc-file.sh

This DRYs the process, and prevents a mismatch between these
two scripts. It also seems faster.