### PR TITLE
LU-17319 shorten symlink to .clang-format

### DIFF
--- a/setup-repo.sh
+++ b/setup-repo.sh
@@ -52,7 +52,8 @@ function ensure_git_ignores_clang_format_file() {
 }
 
 function symlink_clang_format() {
-  $(ln -sf "$DIR/.clang-format" ".clang-format")
+  LINKDIR=$( realpath --relative-base=. $DIR )
+  $(ln -sf "$LINKDIR/.clang-format" ".clang-format")
 }
 
 ensure_pre_commit_file_exists && ensure_pre_commit_file_is_executable && ensure_hook_is_installed && ensure_git_ignores_clang_format_file && symlink_clang_format


### PR DESCRIPTION
https://levelup.atlassian.net/browse/LU-17319

The present setup script creates a fully-pathed symlink:
```
.clang-format -> /Users/claybridges/lu/agios/pret-a-manger/Pods/SpaceCommander/.clang-format
```
We can shorten this using the relative path, as
```
.clang-format -> pods/SpaceCommander/.clang-format
```


