### PR TITLE
Don't lint "WL-Swift.h"

### DIFF
--- a/lib/common-lib.sh
+++ b/lib/common-lib.sh
@@ -28,7 +28,8 @@ function objc_files_to_format() {
 	optional_base_sha="$1"
 	directories_to_check
 	# optional_base_sha is intentionally unescaped so that it will not appear as empty quotes.
-	files=$(git diff --name-only $optional_base_sha --diff-filter=ACMR -- $locations_to_diff | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+	files=$(git diff --name-only $optional_base_sha --diff-filter=ACMR -- $locations_to_diff ':!*WL-Swift.h' | grep -e '\.m$' -e '\.mm$' -e '\.h$' -e '\.hh$')
+
 	directories_to_ignore
 	echo "$files" | grep -v 'Pods/' | grep -v 'Carthage/' >&1
 }


### PR DESCRIPTION
Since the order of imports in "WL-Swift" will be based on dependencies, we don't want to alphabetize it.